### PR TITLE
Fixed #28 "Build status icon toggling" 

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
@@ -269,6 +269,7 @@ public class GitLabWebHook implements UnprotectedRootAction {
         try {
         	URL resourceUrl = new URL(Jenkins.getInstance().getPlugin("gitlab-plugin").getWrapper().baseResourceURL + imageUrl);
         	rsp.serveFile(req, resourceUrl);
+            rsp.flushBuffer();
         } catch (IOException e) {
 			throw HttpResponses.error(500,"Could not generate response.");
 		} finally {

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
@@ -18,6 +18,7 @@ import hudson.security.ACL;
 import hudson.security.csrf.CrumbExclusion;
 import hudson.util.HttpResponses;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -267,10 +268,14 @@ public class GitLabWebHook implements UnprotectedRootAction {
         Authentication old = SecurityContextHolder.getContext().getAuthentication();
         SecurityContextHolder.getContext().setAuthentication(ACL.SYSTEM);
         try {
-        	URL resourceUrl = new URL(Jenkins.getInstance().getPlugin("gitlab-plugin").getWrapper().baseResourceURL + imageUrl);
-        	rsp.serveFile(req, resourceUrl);
+            URL resourceUrl = new URL(Jenkins.getInstance().getPlugin("gitlab-plugin").getWrapper().baseResourceURL + imageUrl);
+            LOGGER.info("serving image "+resourceUrl.toExternalForm());
+            rsp.setHeader("Expires","Fri, 01 Jan 1984 00:00:00 GMT");
+            rsp.setHeader("Cache-Control", "no-cache, private");
+            rsp.setHeader("Content-Type", "image/png");
+            hudson.util.IOUtils.copy(new File(resourceUrl.toURI()), rsp.getOutputStream());
             rsp.flushBuffer();
-        } catch (IOException e) {
+        } catch (Exception e) {
 			throw HttpResponses.error(500,"Could not generate response.");
 		} finally {
             SecurityContextHolder.getContext().setAuthentication(old);


### PR DESCRIPTION
by adding a flushBuffer of the request after the image is served.
This is a candidate to fix #28