### PR TITLE
Fix buildOpenMergeRequests only fetching 20 merge requests from the project

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
@@ -44,6 +44,8 @@ import org.acegisecurity.Authentication;
 import org.acegisecurity.context.SecurityContextHolder;
 import org.apache.commons.io.IOUtils;
 import org.eclipse.jgit.lib.ObjectId;
+import org.gitlab.api.models.GitlabMergeRequest;
+import org.gitlab.api.models.GitlabProject;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
@@ -106,7 +108,7 @@ public class GitLabWebHook implements UnprotectedRootAction {
         while (restOfPathParts.hasNext()) {
             paths.add(restOfPathParts.next());
         }
-        
+
         String token = req.getParameter("token");
 
         //TODO: Check token authentication with project id. For now we are not using this.
@@ -350,9 +352,12 @@ public class GitLabWebHook implements UnprotectedRootAction {
 	protected void buildOpenMergeRequests(GitLabPushTrigger trigger, Integer projectId, String projectRef) {
 		try {
 			GitLab api = new GitLab();
-			List<org.gitlab.api.models.GitlabMergeRequest> reqs = api.instance().getMergeRequests(projectId);
-			for (org.gitlab.api.models.GitlabMergeRequest mr : reqs) {
-				if (!mr.isClosed() && !mr.isMerged()&& projectRef.endsWith(mr.getSourceBranch())) {
+			// TODO Replace this with a call to GitlabAPI.getOpenMergeRequests, once timols has deployed version 1.1.7
+			String tailUrl = GitlabProject.URL + "/" + projectId + GitlabMergeRequest.URL + "?state=opened&per_page=100";
+			List<GitlabMergeRequest> mergeRequests = api.instance().retrieve().getAll(tailUrl, GitlabMergeRequest[].class);
+
+			for (org.gitlab.api.models.GitlabMergeRequest mr : mergeRequests) {
+				if (projectRef.endsWith(mr.getSourceBranch())) {
 					LOGGER.log(Level.FINE,
 							"Generating new merge trigger from "
 									+ mr.toString() + "\n source: "


### PR DESCRIPTION
* It now iterates trough all merge requests, not only the first 20
* It now fetches 100 instead of 20 per rest call (100 is max)
* It only fetches open merge requests now instead of all

Our merge request builder was never triggered because of that bug.
After fixing this bug I still wasn't happy with the performance because we have projects with ~1000 merge requests, which means ~50 rest API requests, which is highly inefficient. I decided to not use the API method GitlabApi.getOpenMergeRequests directly, because it doesn't use the ?state=opened query parameter in 1.1.4, and for some unknown reason timols didn't deploy 1.1.7 yet on the Maven repository. Once 1.1.7 is out, the API method can be used directly again (I left a TODO).

https://github.com/timols/java-gitlab-api/issues/43