### PR TITLE
Fix broken build links since GitLab 7.10

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
@@ -108,6 +108,14 @@ public class GitLabWebHook implements UnprotectedRootAction {
         while (restOfPathParts.hasNext()) {
             paths.add(restOfPathParts.next());
         }
+        
+        // remove everything till we found 'commits'
+        for (Iterator<String> it = paths.iterator(); it.hasNext();) {
+            String path = it.next();
+            if (path.equals("commits"))
+            	break;
+            it.remove();
+        }
 
         String token = req.getParameter("token");
 


### PR DESCRIPTION
This will fixes the broken build links since GitLab 7.10 (fixes #74 and #56)