### PR TITLE
Better approach for fixing broken build links since GitLab 7.10

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
@@ -80,7 +80,7 @@ public class GitLabWebHook implements UnprotectedRootAction {
     }
 
     public void getDynamic(final String projectName, final StaplerRequest req, StaplerResponse res) {
-        LOGGER.log(Level.WARNING, "WebHook called.");
+        LOGGER.log(Level.INFO, "WebHook called with url: {0}", req.getRestOfPath());
         final Iterator<String> restOfPathParts = Splitter.on('/').omitEmptyStrings().split(req.getRestOfPath()).iterator();
         final AbstractProject<?, ?>[] projectHolder = new AbstractProject<?, ?>[] { null };
         ACL.impersonate(ACL.SYSTEM, new Runnable() {

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
@@ -52,6 +52,7 @@ import org.kohsuke.stapler.StaplerResponse;
 import com.dabsquared.gitlabjenkins.GitLabMergeRequest;
 import com.dabsquared.gitlabjenkins.GitLabPushRequest;
 import com.dabsquared.gitlabjenkins.GitLabPushTrigger;
+import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 
 /**
@@ -109,12 +110,23 @@ public class GitLabWebHook implements UnprotectedRootAction {
             paths.add(restOfPathParts.next());
         }
         
-        // remove everything till we found 'commits'
-        for (Iterator<String> it = paths.iterator(); it.hasNext();) {
-            String path = it.next();
-            if (path.equals("commits"))
-            	break;
-            it.remove();
+        /*
+         * Since GitLab 7.10 the URL contains the pushed branch name.
+         * Extract and store the branch name for further processing.
+         * http://jenkins.host.com/project/<ProjectName>/refs/<branchName>/commit/<SHA1>
+         */
+        String sourceBranch = null;
+        if (!paths.isEmpty() && paths.get(0).equals("refs")) {
+            int index = paths.lastIndexOf("commits");
+            if (index == -1)
+                index = paths.lastIndexOf("builds");
+            if (index == -1)
+                index = paths.lastIndexOf("!builds");
+            
+            if (index > 1) {
+                sourceBranch = Joiner.on('/').join(paths.subList(1, index)); // extract branch
+                paths.subList(0, index).clear(); // remove 'refs/<branchName>'
+            }
         }
 
         String token = req.getParameter("token");


### PR DESCRIPTION
This is a follow-up for #76 to fix the issue with the new webhook url (which holds the pushed ref) introduced in GitLab 7.10. I've also changed the logging to contain the request path and changed the log level from WARNING to INFO.

@bassrock mind taking a look.