### PR TITLE
Gitlab action type env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ These include:
 * gitlabSourceRepoURL
 * gitlabSourceRepoName
 * gitlabBranch (This is optional and can be used in shell scripts for the branch being built by the push request)
-* gitlabActionType (This can be either PUSH or MERGE)
+* gitlabActionType (This is optional and can be used in shell scripts or other plugins to change the build behaviour. Possible values are PUSH or MERGE)
 
 
 Help Needed

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ These include:
 * gitlabSourceRepoURL
 * gitlabSourceRepoName
 * gitlabBranch (This is optional and can be used in shell scripts for the branch being built by the push request)
+* gitlabActionType (This can be either PUSH or MERGE)
 
 
 Help Needed

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -165,6 +165,7 @@ public class GitLabPushTrigger extends Trigger<AbstractProject<?, ?>> {
                     LOGGER.log(Level.INFO, "Trying to get name and URL for job: {0} using project {1} (push)", new String[]{job.getName(), job.getRootProject().getName()});
                     values.put("gitlabSourceRepoName", new StringParameterValue("gitlabSourceRepoName", getDesc().getSourceRepoNameDefault(job)));
                 	values.put("gitlabSourceRepoURL", new StringParameterValue("gitlabSourceRepoURL", getDesc().getSourceRepoURLDefault(job).toString()));
+                    values.put("gitlabActionType", new StringParameterValue("gitlabActionType", "PUSH"));
                 	
                     List<ParameterValue> listValues = new ArrayList<ParameterValue>(values.values());
 
@@ -223,7 +224,9 @@ public class GitLabPushTrigger extends Trigger<AbstractProject<?, ?>> {
                     Map<String, ParameterValue> values = getDefaultParameters();
                     values.put("gitlabSourceBranch", new StringParameterValue("gitlabSourceBranch", getSourceBranch(req)));
                     values.put("gitlabTargetBranch", new StringParameterValue("gitlabTargetBranch", req.getObjectAttribute().getTargetBranch()));
-                    
+                    values.put("gitlabActionType", new StringParameterValue("gitlabActionType", "MERGE"));
+
+
                     LOGGER.log(Level.INFO, "Trying to get name and URL for job: {0} using project {1}", new String[]{job.getName(), getDesc().project.getName()});
                     String sourceRepoName = getDesc().getSourceRepoNameDefault(job);
                     String sourceRepoURL = getDesc().getSourceRepoURLDefault(job).toString();


### PR DESCRIPTION
Adding new environment variable to indicate if trigger was due to PUSH or MERGE.

This will allow for the use of conditional build step to change the behaviour of the build.

If this is possible another way, please let me know.