### PR TITLE
Configurable rebuild options

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabMergeRequest.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabMergeRequest.java
@@ -95,7 +95,8 @@ public class GitLabMergeRequest extends GitLabRequest {
         private Branch target;
 
         private LastCommit lastCommit;
-
+        
+        private String action;
 
         public ObjectAttributes() {
         }
@@ -239,6 +240,14 @@ public class GitLabMergeRequest extends GitLabRequest {
 
         public void setLastCommit(LastCommit lastCommit) {
             this.lastCommit = lastCommit;
+        }
+        
+        public String getAction() {
+            return action;
+        }
+
+        public void setAction(String action) {
+            this.action = action;
         }
     }
 

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -23,6 +23,8 @@ import hudson.triggers.TriggerDescriptor;
 import hudson.util.FormValidation;
 import hudson.util.SequentialExecutionQueue;
 import hudson.util.XStream2;
+import hudson.util.ListBoxModel;
+import hudson.util.ListBoxModel.Option;
 
 import java.io.File;
 import java.io.IOException;
@@ -73,7 +75,7 @@ public class GitLabPushTrigger extends Trigger<AbstractProject<?, ?>> {
 	private static final Logger LOGGER = Logger.getLogger(GitLabPushTrigger.class.getName());
 	private boolean triggerOnPush = true;
     private boolean triggerOnMergeRequest = true;
-    private boolean triggerOpenMergeRequestOnPush = true;
+    private final String triggerOpenMergeRequestOnPush;
     private boolean ciSkip = true;
     private boolean setBuildDescription = true;
     private boolean addNoteOnMergeRequest = true;
@@ -83,7 +85,7 @@ public class GitLabPushTrigger extends Trigger<AbstractProject<?, ?>> {
     private final String excludeBranchesSpec;
 
     @DataBoundConstructor
-    public GitLabPushTrigger(boolean triggerOnPush, boolean triggerOnMergeRequest, boolean triggerOpenMergeRequestOnPush, boolean ciSkip, boolean setBuildDescription, boolean addNoteOnMergeRequest, boolean addVoteOnMergeRequest, boolean allowAllBranches,
+    public GitLabPushTrigger(boolean triggerOnPush, boolean triggerOnMergeRequest, String triggerOpenMergeRequestOnPush, boolean ciSkip, boolean setBuildDescription, boolean addNoteOnMergeRequest, boolean addVoteOnMergeRequest, boolean allowAllBranches,
             String includeBranchesSpec, String excludeBranchesSpec) {
         this.triggerOnPush = triggerOnPush;
         this.triggerOnMergeRequest = triggerOnMergeRequest;
@@ -105,7 +107,7 @@ public class GitLabPushTrigger extends Trigger<AbstractProject<?, ?>> {
     	return triggerOnMergeRequest;
     }
 
-    public boolean getTriggerOpenMergeRequestOnPush() {
+    public String getTriggerOpenMergeRequestOnPush() {
         return triggerOpenMergeRequestOnPush;
     }
 
@@ -509,6 +511,12 @@ public class GitLabPushTrigger extends Trigger<AbstractProject<?, ?>> {
             save();
             gitlab = new GitLab();
             return super.configure(req, formData);
+        }
+        
+        public ListBoxModel doFillTriggerOpenMergeRequestOnPushItems(@QueryParameter String triggerOpenMergeRequestOnPush) {
+            return new ListBoxModel(new Option("Never", "never", triggerOpenMergeRequestOnPush.matches("never") ),
+                    new Option("On push to source branch", "source", triggerOpenMergeRequestOnPush.matches("source") ),
+                    new Option("On push to source or target branch", "both", triggerOpenMergeRequestOnPush.matches("both") ));
         }
 
         private List<String> getProjectBranches(final Job<?, ?> job) throws IOException, IllegalStateException {

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -270,7 +270,7 @@ public class GitLabPushTrigger extends Trigger<AbstractProject<?, ?>> {
                     values.put("gitlabActionType", new StringParameterValue("gitlabActionType", "MERGE"));
 
 
-                    LOGGER.log(Level.INFO, "Trying to get name and URL for job: {0} using project {1}", new String[]{job.getName(), getDesc().project.getName()});
+                    LOGGER.log(Level.INFO, "Trying to get name and URL for job: {0}", job.getName());
                     String sourceRepoName = getDesc().getSourceRepoNameDefault(job);
                     String sourceRepoURL = getDesc().getSourceRepoURLDefault(job).toString();
                     

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
@@ -368,7 +368,7 @@ public class GitLabWebHook implements UnprotectedRootAction {
 
             trigger.onPost(request);
 
-            if (trigger.getTriggerOpenMergeRequestOnPush()) {
+            if (!trigger.getTriggerOpenMergeRequestOnPush().equals("never")) {
             	// Fetch and build open merge requests with the same source branch
             	buildOpenMergeRequests(trigger, request.getProject_id(), request.getRef());
             }
@@ -385,7 +385,8 @@ public class GitLabWebHook implements UnprotectedRootAction {
 			List<GitlabMergeRequest> mergeRequests = api.instance().retrieve().getAll(tailUrl, GitlabMergeRequest[].class);
 
 			for (org.gitlab.api.models.GitlabMergeRequest mr : mergeRequests) {
-				if (projectRef.endsWith(mr.getSourceBranch()) || projectRef.endsWith(mr.getTargetBranch())) {
+				if (projectRef.endsWith(mr.getSourceBranch()) || 
+                                        (trigger.getTriggerOpenMergeRequestOnPush().equals("both") && projectRef.endsWith(mr.getTargetBranch()))) {
 					LOGGER.log(Level.FINE,
 							"Generating new merge trigger from "
 									+ mr.toString() + "\n source: "

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
@@ -440,6 +440,10 @@ public class GitLabWebHook implements UnprotectedRootAction {
         	LOGGER.log(Level.INFO, "Accepted Merge Request, no build started");
             return;
         }
+        if(request.getObjectAttribute().getAction().equals("update")) {
+        	LOGGER.log(Level.INFO, "Existing Merge Request, build will be trigged by buildOpenMergeRequests instead");
+            return;
+        }
         if(request.getObjectAttribute().getLastCommit()!=null) {
             AbstractBuild mergeBuild = getBuildBySHA1(project, request.getObjectAttribute().getLastCommit().getId(), true);
             if(mergeBuild!=null){

--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabWebHook.java
@@ -420,7 +420,6 @@ public class GitLabWebHook implements UnprotectedRootAction {
 					} finally {
 						SecurityContextHolder.getContext().setAuthentication(old);
 					}
-					return;
 				}
 			}
 		} catch (Exception e) {

--- a/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/config.jelly
+++ b/src/main/resources/com/dabsquared/gitlabjenkins/GitLabPushTrigger/config.jelly
@@ -6,8 +6,8 @@
     <f:entry title="Build on Push Events" field="triggerOnPush">
       <f:checkbox default="true" />
     </f:entry>
-    <f:entry title="Rebuild open Merge Requests on Push Events" field="triggerOpenMergeRequestOnPush">
-      <f:checkbox default="true" />
+    <f:entry title="Rebuild open Merge Requests" field="triggerOpenMergeRequestOnPush">
+      <f:select/>
     </f:entry>
     <f:entry title="Enable [ci-skip]" field="ciSkip">
       <f:checkbox default="true" />


### PR DESCRIPTION
This extends #94 so that you can choose whether open merge requests should be:
a) Never rebuilt
b) Rebuilt on push to source branch
c) Rebuilt on push to source or target branch

If you have a lot of open MRs, and a slow jenkins job, then running them all when a change is pushed to master isn't ideal.

I have also fixed a bug whereby only 1 open MR would be rebuilt on a push to master (7f8f9f8) and fixed a null pointer exception in a log message.

Finally I tweaked the handler for the merge request hook so that it only schedules runs when an MR is first opened.  Once it is opened, rebuilds are triggered by the buildOpenMergeRequest function, triggered from the push hook sent via the GitlabCI service.