### PR TITLE
Fix NPE on Gitlab push event

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -121,7 +121,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
     public boolean getAddNoteOnMergeRequest() {
         return addNoteOnMergeRequest;
     }
-    
+
     public boolean getAddVoteOnMergeRequest() {
         return addVoteOnMergeRequest;
     }
@@ -156,11 +156,11 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
     }
 
     public String getIncludeBranchesSpec() {
-        return this.includeBranchesSpec;
+        return this.includeBranchesSpec == null ? "" : this.includeBranchesSpec;
     }
 
     public String getExcludeBranchesSpec() {
-        return this.excludeBranchesSpec;
+        return this.excludeBranchesSpec == null ? "" : this.excludeBranchesSpec;
     }
 
     // executes when the Trigger receives a push request
@@ -179,7 +179,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
                 public void run() {
             		LOGGER.log(Level.INFO, "{0} triggered for push.", job.getName());
 
-            		String name = " #" + job.getNextBuildNumber();                    
+            		String name = " #" + job.getNextBuildNumber();
             		GitLabPushCause cause = createGitLabPushCause(req);
             		Action[] actions = createActions(req);
 
@@ -236,7 +236,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
                     values.put("gitlabSourceRepoName", new StringParameterValue("gitlabSourceRepoName", getDesc().getSourceRepoNameDefault(job)));
                 	values.put("gitlabSourceRepoURL", new StringParameterValue("gitlabSourceRepoURL", getDesc().getSourceRepoURLDefault(job).toString()));
                     values.put("gitlabActionType", new StringParameterValue("gitlabActionType", "PUSH"));
-                	
+
                     List<ParameterValue> listValues = new ArrayList<ParameterValue>(values.values());
 
                     ParametersAction parametersAction = new ParametersAction(listValues);
@@ -258,7 +258,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
                     Action[] actionsArray = actions.toArray(new Action[0]);
 
                     return actionsArray;
-                }                              
+                }
             });
         }
     }
@@ -270,7 +270,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
                 public void run() {
 	                LOGGER.log(Level.INFO, "{0} triggered for merge request.", job.getName());
                   String name = " #" + job.getNextBuildNumber();
-                  
+
 	                GitLabMergeCause cause = createGitLabMergeCause(req);
 	                Action[] actions = createActions(req);
                     ParameterizedJobMixIn scheduledJob = new ParameterizedJobMixIn() {
@@ -318,17 +318,17 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
                     LOGGER.log(Level.INFO, "Trying to get name and URL for job: {0}", job.getName());
                     String sourceRepoName = getDesc().getSourceRepoNameDefault(job);
                     String sourceRepoURL = getDesc().getSourceRepoURLDefault(job).toString();
-                    
-                    if (!getDescriptor().getGitlabHostUrl().isEmpty()) {                                        
+
+                    if (!getDescriptor().getGitlabHostUrl().isEmpty()) {
                     	// Get source repository if communication to Gitlab is possible
                     	try {
-                        	sourceRepoName = req.getSourceProject(getDesc().getGitlab()).getPathWithNamespace();    
+                        	sourceRepoName = req.getSourceProject(getDesc().getGitlab()).getPathWithNamespace();
                         	sourceRepoURL = req.getSourceProject(getDesc().getGitlab()).getSshUrl();
                         } catch (IOException ex) {
-                        	LOGGER.log(Level.WARNING, "Could not fetch source project''s data from Gitlab. '('{0}':' {1}')'", new String[]{ex.toString(), ex.getMessage()});                        	
+                        	LOGGER.log(Level.WARNING, "Could not fetch source project''s data from Gitlab. '('{0}':' {1}')'", new String[]{ex.toString(), ex.getMessage()});
                         }
                     }
-                    
+
                     values.put("gitlabSourceRepoName", new StringParameterValue("gitlabSourceRepoName", sourceRepoName));
                 	values.put("gitlabSourceRepoURL", new StringParameterValue("gitlabSourceRepoURL", sourceRepoURL));
 
@@ -341,12 +341,12 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
 
                     return actionsArray;
                 }
-                
-                
-            });	
+
+
+            });
     	}
     }
-    
+
     private Map<String, ParameterValue> getDefaultParameters() {
         Map<String, ParameterValue> values = new HashMap<String, ParameterValue>();
         ParametersDefinitionProperty definitionProperty = job.getProperty(ParametersDefinitionProperty.class);
@@ -422,10 +422,10 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
     	} else {
     		result = ((GitLabMergeRequest)req).getObjectAttribute().getSourceBranch();
     	}
-    	
+
     	return result;
     }
-    
+
     @Override
     public DescriptorImpl getDescriptor() {
         return DescriptorImpl.get();
@@ -437,7 +437,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
 
     public File getLogFile() {
         return new File(job.getRootDir(), "gitlab-polling.log");
-    }    
+    }
 
     public static final class ConverterImpl extends XStream2.PassthruConverter<GitLabPushTrigger> {
 
@@ -510,7 +510,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
         public DescriptorImpl() {
         	load();
         }
-        
+
         @Override
         public boolean isApplicable(Item item) {
             if(item instanceof Job && SCMTriggerItems.asSCMTriggerItem(item) != null
@@ -529,7 +529,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
             }
 
             final List<String> projectParentsUrl = new ArrayList<String>();
-            
+
             try {
 				for (Object parent = project.getParent(); parent instanceof Item; parent = ((Item) parent)
 						.getParent()) {
@@ -560,7 +560,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
             gitlab = new GitLab();
             return super.configure(req, formData);
         }
-        
+
         public ListBoxModel doFillTriggerOpenMergeRequestOnPushItems(@QueryParameter String triggerOpenMergeRequestOnPush) {
             return new ListBoxModel(new Option("Never", "never", triggerOpenMergeRequestOnPush.matches("never") ),
                     new Option("On push to source branch", "source", triggerOpenMergeRequestOnPush.matches("source") ),
@@ -636,11 +636,11 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
             final AutoCompletionCandidates ac = new AutoCompletionCandidates();
             List<String> values = ac.getValues();
 
-            try {  
+            try {
                 List<String> branches = this.getProjectBranches(job);
                 // show all suggestions for short strings
                 if (query.length() < 2){
-                    values.addAll(branches);              
+                    values.addAll(branches);
                 }
                 else {
                     for (String branch : branches){
@@ -717,7 +717,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
         /**
          * Get the URL of the first declared repository in the project configuration.
          * Use this as default source repository url.
-         * 
+         *
          * @return URIish the default value of the source repository url
          * @throws IllegalStateException Project does not use git scm.
          */
@@ -746,11 +746,11 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
 
             return null;
         }
-        
+
         /**
          * Get the Name of the first declared repository in the project configuration.
          * Use this as default source repository Name.
-         * 
+         *
          * @return String with the default name of the source repository
          */
         protected String getSourceRepoNameDefault(Job job) {
@@ -761,15 +761,15 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
                 LOGGER.log(
                         Level.WARNING,
                         "Could not find GitSCM for project. Project = {1}, next build = {2}",
-                        new String[] { 
+                        new String[] {
                                 project.getName(),
                                 String.valueOf(project.getNextBuildNumber()) });
                 throw new IllegalArgumentException("This project does not use git:" + project.getName());
             } else {
                 List<RemoteConfig> repositories = gitSCM.getRepositories();
                 if (!repositories.isEmpty()){
-                    result = repositories.get(repositories.size()-1).getName();                                                        
-                }           
+                    result = repositories.get(repositories.size()-1).getName();
+                }
             }
             return result;
         }
@@ -777,7 +777,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
         public FormValidation doCheckGitlabHostUrl(@QueryParameter String value) {
             if (value == null || value.isEmpty()) {
                 return FormValidation.error("Gitlab host URL required.");
-            }        
+            }
 
             return FormValidation.ok();
         }
@@ -785,11 +785,11 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
         public FormValidation doCheckGitlabApiToken(@QueryParameter String value) {
             if (value == null || value.isEmpty()) {
                 return FormValidation.error("API Token for Gitlab access required");
-            }   
-            
+            }
+
             return FormValidation.ok();
-        }        
-        
+        }
+
         public FormValidation doTestConnection(@QueryParameter("gitlabHostUrl") final String hostUrl,
                 @QueryParameter("gitlabApiToken") final String token, @QueryParameter("ignoreCertificateErrors") final boolean ignoreCertificateErrors) throws IOException {
             try {
@@ -798,7 +798,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
             } catch (IOException e) {
                 return FormValidation.error("Client error : "+e.getMessage());
             }
-        }        
+        }
 
         public GitLab getGitlab() {
             if (gitlab == null) {
@@ -814,7 +814,7 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
         public String getGitlabHostUrl() {
             return gitlabHostUrl;
         }
-        
+
         public boolean getIgnoreCertificateErrors() {
         	return ignoreCertificateErrors;
         }


### PR DESCRIPTION
This just adds a little null-safety to prevent the stacktrace that we're experiencing below:

```
Caused by: java.lang.NullPointerException
	at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:187)
	at com.google.common.base.Splitter.split(Splitter.java:371)
	at com.dabsquared.gitlabjenkins.GitLabPushTrigger$DescriptorImpl.splitBranchSpec(GitLabPushTrigger.java:630)
	at com.dabsquared.gitlabjenkins.GitLabPushTrigger$DescriptorImpl.access$000(GitLabPushTrigger.java:499)
	at com.dabsquared.gitlabjenkins.GitLabPushTrigger.isBranchAllowed(GitLabPushTrigger.java:137)
	at com.dabsquared.gitlabjenkins.GitLabPushTrigger.onPost(GitLabPushTrigger.java:176)
	at com.dabsquared.gitlabjenkins.GitLabWebHook.generatePushBuild(GitLabWebHook.java:400)
	at com.dabsquared.gitlabjenkins.GitLabWebHook.generateBuild(GitLabWebHook.java:360)
	at com.dabsquared.gitlabjenkins.GitLabWebHook.getDynamic(GitLabWebHook.java:157)
```